### PR TITLE
Bump ic-repl

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DFX_VERSION: 0.13.0
+      DFX_VERSION: 0.13.1
       VESSEL_VERSION: v0.6.4
       IC_REPL_VERSION: 0.3.15
     steps:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       DFX_VERSION: 0.13.0
       VESSEL_VERSION: v0.6.4
-      IC_REPL_VERSION: 0.3.14
+      IC_REPL_VERSION: 0.3.15
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Community contributions are strongly encouraged.
 
 ## Performance report
 
-Performance reports are generated in `gh-pages` branch. For some technical reasons, the flamegraph is from right to left.
-The reported Wasm binary size is after the instrumentation.
+Performance reports are generated in `gh-pages` branch. The reported Wasm binary size is after the instrumentation.
 
 * [Sample dapps](http://dfinity.github.io/canister-profiling/dapps)
 * [Collection libraries](http://dfinity.github.io/canister-profiling/collections)


### PR DESCRIPTION
The flamegraph is now from left to right. Also avoid collapsing of adjacent same-name function calls.