### PR TITLE
Add btrees with different orders to test which order is most optimal with the current benchmarks

### DIFF
--- a/collections/motoko/package-set.dhall
+++ b/collections/motoko/package-set.dhall
@@ -15,7 +15,7 @@ let
           }
         , { name = "btreemap"
           , repo = "https://github.com/canscale/StableHeapBTreeMap"
-          , version = "main"
+          , version = "v0.3.0"
           , dependencies = [ "base" ] : List Text
           }
         , { name = "ZhenyaHashmap"

--- a/collections/motoko/src/btreemap.mo
+++ b/collections/motoko/src/btreemap.mo
@@ -5,7 +5,7 @@ import Option "mo:base/Option";
 import Random "random";
 
 actor {
-    stable var map = Map.init<Nat32, Text>(?8);
+    stable var map = Map.init<Nat32, Text>(null);
     let rand = Random.new(null, 42);
 
     public func generate(size: Nat) : async () {


### PR DESCRIPTION
Thought this might be interesting to how BTrees of different orders perform with the benchmark.

Also, it might be useful once DTS is included and you go beyond inserting 50k objects. I think 4X DTS is now live in dfx >= 0.13.0