### PR TITLE
bump moc and add diff for CI

### DIFF
--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -33,9 +33,9 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d < 0:
-                    result.loc[idx, col] = f"{x:_} (\textcolor{{green}}{{{d:.2f}\\%}})"
+                    result.loc[idx, col] = f"{x:_} (\\textcolor{{green}}{{{d:.2f}\\%}})"
                 elif d > 0:
-                    result.loc[idx, col] = f"{x:_} (\textcolor{{red}}{{{d:.2f}\\%}})"
+                    result.loc[idx, col] = f"{x:_} (\\textcolor{{red}}{{{d:.2f}\\%}})"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -33,9 +33,9 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d < 0:
-                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\%$}})"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\%}}$)"
                 elif d > 0:
-                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{red}}{{{d:.2f}\\%$}})"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{red}}{{{d:.2f}\\%}}$)"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -32,8 +32,10 @@ for i, (current, main) in enumerate(zip(current, main)):
             for col in current.columns:
                 x = row[col]
                 d = diff.loc[idx, col]
-                if d != 0:
-                    result.loc[idx, col] = f"{x:_} ({d:.2f}%)"
+                if d < 0:
+                    result.loc[idx, col] = f"{x:_} (<span style='color:green'>{d:.2f}%</span>)"
+                elif d > 0:
+                    result.loc[idx, col] = f"{x:_} (<span style='color:red'>{d:.2f}%</span>)"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -33,9 +33,9 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d < 0:
-                    result.loc[idx, col] = f"{x:_} (\\textcolor{{green}}{{{d:.2f}\\%}})"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\%$}})"
                 elif d > 0:
-                    result.loc[idx, col] = f"{x:_} (\\textcolor{{red}}{{{d:.2f}\\%}})"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{red}}{{{d:.2f}\\%$}})"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -33,9 +33,9 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d < 0:
-                    result.loc[idx, col] = f"{x:_} (<span style='color:green'>{d:.2f}%</span>)"
+                    result.loc[idx, col] = f"{x:_} (\textcolor{{green}}{{{d:.2f}\\%}})"
                 elif d > 0:
-                    result.loc[idx, col] = f"{x:_} (<span style='color:red'>{d:.2f}%</span>)"
+                    result.loc[idx, col] = f"{x:_} (\textcolor{{red}}{{{d:.2f}\\%}})"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -1,18 +1,47 @@
 import sys
 import pandas as pd
 import markdown
+import re
 
 if len(sys.argv) < 3:
     print("Usage: python diff.py [current.md] [main.md]")
     sys.exit(1)
+
+def extract_header_for_each_table(html_text):
+    # Extract the tables from the HTML
+    table_regex = r'<table>(.*?)</table>'
+    tables = re.findall(table_regex, html_text, re.DOTALL)
+    
+    # Find the nearest header that comes before each table
+    result = []
+    for table in tables:
+        # Find the index of the table in the HTML text
+        table_index = html_text.find(table)
+        
+        # Find the nearest header by searching backwards
+        header_regex = r'<h(\d)>(.*?)</h\1>'
+        header_match = re.findall(header_regex, html_text[:table_index])[-1]
+        if header_match is None:
+            result.append("# Unknonw header")
+            continue  # No header found before this table
+        
+        # Extract the header text and level and add the header and table to the result
+        header_level = int(header_match[0])
+        header_text = header_match[1]
+        result.append('#' * header_level + ' ' + header_text)
+    return result
 
 def read_tables(file):
     try:
         with open(file, "r") as f:
             md = f.read()
             html = markdown.markdown(md, extensions=['tables'])
+            headers = extract_header_for_each_table(html)
             tables = pd.read_html(html, thousands = '_', index_col = 0)
-            return tables
+            if len(headers) != len(tables):
+                print(f"Bad {file}", file=sys.stderr)
+                sys.exit(1)
+            return list(zip(headers, tables))
     except OSError as e:
         print(f"> **Warning**\n> Skip {file}. File not found.\n")
         sys.exit(0)
@@ -24,15 +53,14 @@ if len(current) != len(main):
     print(f"> **Warning**\n> Skip {sys.argv[1]}, due to the number of tables mismatches from main branch.\n")
     sys.exit(0)
 
-for i, (current, main) in enumerate(zip(current, main)):
-    if current.shape == main.shape and all(current.columns == main.columns) and all(current.index == main.index):
-        #diff = (current - main) / main * 100
+for i, ((header, current), (header2, main)) in enumerate(zip(current, main)):
+    if header == header2 and current.shape == main.shape and all(current.columns == main.columns) and all(current.index == main.index):
         result = pd.DataFrame(index=current.index, columns=current.columns)
-        print(sys.argv[1], i, file=sys.stderr)
+        print(sys.argv[1], i, header, file=sys.stderr)
+        print(f"\n{header}\n")
         for idx, row in current.iterrows():
             for col in current.columns:
                 x = row[col]
-                #d = diff.loc[idx, col]
                 base = main.loc[idx, col]
                 d = (x - base) / base * 100
                 if d < 0:
@@ -44,5 +72,5 @@ for i, (current, main) in enumerate(zip(current, main)):
         print(result.to_markdown())
         print(f"\n")
     else:
-        print(f"> **Warning**\n> Skip table {i} from {sys.argv[1]}, due to table shape mismatches from main branch.\n")
+        print(f"> **Warning**\n> Skip table {i} {header} from {sys.argv[1]}, due to table shape mismatches from main branch.\n")
 

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -33,9 +33,9 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d < 0:
-                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\%}}$)"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\\\%}}$)"
                 elif d > 0:
-                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{red}}{{{d:.2f}\\%}}$)"
+                    result.loc[idx, col] = f"{x:_} ($\\textcolor{{red}}{{{d:.2f}\\\\%}}$)"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -26,12 +26,15 @@ if len(current) != len(main):
 
 for i, (current, main) in enumerate(zip(current, main)):
     if current.shape == main.shape and all(current.columns == main.columns) and all(current.index == main.index):
-        diff = (current - main) / main * 100
+        #diff = (current - main) / main * 100
         result = pd.DataFrame(index=current.index, columns=current.columns)
+        print(sys.argv[1], i, file=sys.stderr)
         for idx, row in current.iterrows():
             for col in current.columns:
                 x = row[col]
-                d = diff.loc[idx, col]
+                #d = diff.loc[idx, col]
+                base = main.loc[idx, col]
+                d = (x - base) / base * 100
                 if d < 0:
                     result.loc[idx, col] = f"{x:_} ($\\textcolor{{green}}{{{d:.2f}\\\\%}}$)"
                 elif d > 0:

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -1,0 +1,35 @@
+import sys
+import pandas as pd
+import markdown
+
+if len(sys.argv) < 3:
+    print("Usage: python extract_tables.py [current.md] [main.md]")
+    sys.exit(1)
+
+def read_tables(file):
+    with open(file, "r") as f:
+        md = f.read()
+        html = markdown.markdown(md, extensions=['tables'])
+        tables = pd.read_html(html, thousands = '_', index_col = 0)
+        return tables
+
+current = read_tables(sys.argv[1])
+main = read_tables(sys.argv[2])
+
+for i, (current, main) in enumerate(zip(current, main)):
+    if current.shape == main.shape and all(current.columns == main.columns) and all(current.index == main.index):
+        diff = (current - main) / main * 100
+        result = pd.DataFrame(index=current.index, columns=current.columns)
+        for idx, row in current.iterrows():
+            for col in current.columns:
+                x = row[col]
+                d = diff.loc[idx, col]
+                if d != 0:
+                    result.loc[idx, col] = f"{x:_}({d:.2f}%)"
+                else:
+                    result.loc[idx, col] = f"{x:_}"
+        print(result.to_markdown())
+    else:
+        print(f"print only current")
+        print(current.to_markdown())
+

--- a/.github/workflows/diff.py
+++ b/.github/workflows/diff.py
@@ -3,18 +3,26 @@ import pandas as pd
 import markdown
 
 if len(sys.argv) < 3:
-    print("Usage: python extract_tables.py [current.md] [main.md]")
+    print("Usage: python diff.py [current.md] [main.md]")
     sys.exit(1)
 
 def read_tables(file):
-    with open(file, "r") as f:
-        md = f.read()
-        html = markdown.markdown(md, extensions=['tables'])
-        tables = pd.read_html(html, thousands = '_', index_col = 0)
-        return tables
+    try:
+        with open(file, "r") as f:
+            md = f.read()
+            html = markdown.markdown(md, extensions=['tables'])
+            tables = pd.read_html(html, thousands = '_', index_col = 0)
+            return tables
+    except OSError as e:
+        print(f"> **Warning**\n> Skip {file}. File not found.\n")
+        sys.exit(0)
 
 current = read_tables(sys.argv[1])
 main = read_tables(sys.argv[2])
+
+if len(current) != len(main):
+    print(f"> **Warning**\n> Skip {sys.argv[1]}, due to the number of tables mismatches from main branch.\n")
+    sys.exit(0)
 
 for i, (current, main) in enumerate(zip(current, main)):
     if current.shape == main.shape and all(current.columns == main.columns) and all(current.index == main.index):
@@ -25,11 +33,11 @@ for i, (current, main) in enumerate(zip(current, main)):
                 x = row[col]
                 d = diff.loc[idx, col]
                 if d != 0:
-                    result.loc[idx, col] = f"{x:_}({d:.2f}%)"
+                    result.loc[idx, col] = f"{x:_} ({d:.2f}%)"
                 else:
                     result.loc[idx, col] = f"{x:_}"
         print(result.to_markdown())
+        print(f"\n")
     else:
-        print(f"print only current")
-        print(current.to_markdown())
+        print(f"> **Warning**\n> Skip table {i} from {sys.argv[1]}, due to table shape mismatches from main branch.\n")
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           find _out/ -name 'README.md' -exec cat {} \; > TABLE_OLD.md
           cd _out
-          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} main/{} \; > ../TABLE.md
+          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} ../main/{} \; > ../TABLE.md
       - name: Read table
         if: github.event_name == 'pull_request'
         id: perf

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -98,6 +98,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             <!-- diff comment -->
+            > **Note**
+            > Diffing the performance result against the published result from main branch
+            
             ${{ steps.diff.outputs.content }}
           edit-mode: replace
       - name: Find performance comment

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -63,14 +63,10 @@ jobs:
           dfx start --background
       - name: Run perf
         run: make
-      - name: Diff reports
-        if: github.event_name == 'pull_request'
-        run: |
-
       - name: Generate table
         if: github.event_name == 'pull_request'
         run: |
-          # find _out/ -name 'README.md' -exec cat {} \; > TABLE.md
+          find _out/ -name 'README.md' -exec cat {} \; > TABLE_OLD.md
           cd _out
           find . -name 'README.md' -exec python .github/workflows/diff.py {} main/{} \; > TABLE.md
       - name: Read table

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           find _out/ -name 'README.md' -exec cat {} \; > TABLE_OLD.md
           cd _out
-          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} main/{} \; > TABLE.md
+          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} main/{} \; > ../TABLE.md
       - name: Read table
         if: github.event_name == 'pull_request'
         id: perf

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -66,10 +66,13 @@ jobs:
       - name: Diff reports
         if: github.event_name == 'pull_request'
         run: |
-          python .github/workflows/diff.py _out/dapps/README.md main/dapps/README.md
+
       - name: Generate table
         if: github.event_name == 'pull_request'
-        run: find _out/ -name 'README.md' -exec cat {} \; > TABLE.md
+        run: |
+          # find _out/ -name 'README.md' -exec cat {} \; > TABLE.md
+          cd _out
+          find . -name 'README.md' -exec python .github/workflows/diff.py {} main/{} \; > TABLE.md
       - name: Read table
         if: github.event_name == 'pull_request'
         id: perf

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -17,6 +17,11 @@ jobs:
       MOC_VERSION: 0.8.4
     steps:
       - uses: actions/checkout@v3
+      - name: Checkout out gh-pages report
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: main
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -30,7 +35,16 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}      
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/setup-python@v4
+        if: github.event_name == 'pull_request'
+        with:
+          python-version: "3.9"
+      - name: Install Python dependencies
+        if: github.event_name == 'pull_request'
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas markdown lxml html5lib bs4 tabulate
       - name: Install dfx
         run: |
           echo y | DFX_VERSION=$DFX_VERSION bash -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
@@ -49,6 +63,10 @@ jobs:
           dfx start --background
       - name: Run perf
         run: make
+      - name: Diff reports
+        if: github.event_name == 'pull_request'
+        run: |
+          python .github/workflows/diff.py _out/dapps/README.md main/_out/dapps/README.md
       - name: Generate table
         if: github.event_name == 'pull_request'
         run: find _out/ -name 'README.md' -exec cat {} \; > TABLE.md

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-concurrency:
-  cancel-in-progress: true
 
 jobs:
   perf:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: github.event_name == 'pull_request'
         with:
-          python-version: "3.10"
+          python-version: "3.9"
       - name: Install Python dependencies
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: github.event_name == 'pull_request'
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install Python dependencies
         if: github.event_name == 'pull_request'
         run: |
@@ -67,6 +67,7 @@ jobs:
       - name: Generate table
         if: github.event_name == 'pull_request'
         run: |
+          set -eu
           find _out/ -name 'README.md' -exec cat {} \; > TABLE.md
           cd _out
           find . -name 'README.md' -exec python ../.github/workflows/diff.py {} ../main/{} \; > ../DIFF.md

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Checkout out gh-pages report
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v3
         with:
           ref: gh-pages
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: github.event_name == 'pull_request'
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install Python dependencies
         if: github.event_name == 'pull_request'
         run: |
@@ -66,15 +67,39 @@ jobs:
       - name: Generate table
         if: github.event_name == 'pull_request'
         run: |
-          find _out/ -name 'README.md' -exec cat {} \; > TABLE_OLD.md
+          find _out/ -name 'README.md' -exec cat {} \; > TABLE.md
           cd _out
-          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} ../main/{} \; > ../TABLE.md
+          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} ../main/{} \; > ../DIFF.md
       - name: Read table
         if: github.event_name == 'pull_request'
         id: perf
         uses: juliangruber/read-file-action@v1
         with:
           path: ./TABLE.md
+      - name: Read diff
+        if: github.event_name == 'pull_request'
+        id: diff
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./DIFF.md
+      - name: Find diff comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v2 
+        id: fc_diff
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- diff comment -->'
+      - name: Create or update diff comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.fc_diff.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- diff comment -->
+            ${{ steps.diff.outputs.content }}
+          edit-mode: replace
       - name: Find performance comment
         if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v2 
@@ -84,7 +109,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- perf comment -->'
       - name: Create or update performance comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  cancel-in-progress: true
 
 jobs:
   perf:
@@ -66,7 +68,7 @@ jobs:
       - name: Diff reports
         if: github.event_name == 'pull_request'
         run: |
-          python .github/workflows/diff.py _out/dapps/README.md main/_out/dapps/README.md
+          python .github/workflows/diff.py _out/dapps/README.md main/dapps/README.md
       - name: Generate table
         if: github.event_name == 'pull_request'
         run: find _out/ -name 'README.md' -exec cat {} \; > TABLE.md

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,7 +13,8 @@ jobs:
     env:
       DFX_VERSION: 0.13.1
       VESSEL_VERSION: v0.6.4
-      IC_REPL_VERSION: 0.3.15
+      IC_REPL_VERSION: 0.3.17
+      MOC_VERSION: 0.8.4
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -40,6 +41,9 @@ jobs:
           cp ./vessel-linux64 /usr/local/bin/vessel
           chmod a+x /usr/local/bin/vessel
           dfx cache install
+          cd $(dfx cache show)
+          wget https://github.com/dfinity/motoko/releases/download/$MOC_VERSION/motoko-linux64-$MOC_VERSION.tar.gz
+          tar zxvf motoko-linux64-$MOC_VERSION.tar.gz
       - name: Start dfx
         run: |
           dfx start --background

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           find _out/ -name 'README.md' -exec cat {} \; > TABLE_OLD.md
           cd _out
-          find . -name 'README.md' -exec python .github/workflows/diff.py {} main/{} \; > TABLE.md
+          find . -name 'README.md' -exec python ../.github/workflows/diff.py {} main/{} \; > TABLE.md
       - name: Read table
         if: github.event_name == 'pull_request'
         id: perf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -322,9 +322,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+checksum = "b2e5d13ca2353ab7d0230988629def93914a8c4015f621f9b13ed2955614731d"
 dependencies = [
  "log",
 ]
@@ -356,9 +356,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -381,15 +381,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -398,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -415,21 +415,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -632,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "lalrpop"
@@ -682,9 +682,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "line-col"
@@ -807,15 +807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,18 +839,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -869,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "ordered-float"
@@ -908,15 +899,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -979,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
@@ -1013,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1033,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1094,15 +1085,15 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scopeguard"
@@ -1112,9 +1103,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
 ]
@@ -1130,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1141,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -1152,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274f512d6748a01e67cbcde5b4307ab2c9d52a98a2b870a980ef0793a351deff"
+checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -1190,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -1214,9 +1205,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "string_cache"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
@@ -1268,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1319,18 +1310,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1360,19 +1351,19 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.1"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
 dependencies = [
  "indexmap",
- "nom8",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1389,9 +1380,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1471,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1486,42 +1477,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "winnow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+dependencies = [
+ "memchr",
+]

--- a/collections/README.md
+++ b/collections/README.md
@@ -25,7 +25,6 @@ the same elements, and the queries are exactly the same. Below we explain the me
 > * Due to the instrumentation overhead and cycle limit, we cannot profile computations with large collections. Hopefully, when deterministic time slicing is ready, we can measure the performance on larger memory footprint.
 > * `hashmap` uses amortized data structure. When the initial capacity is reached, it has to copy the whole array, thus the cost of `batch_put 50` is much higher than other data structures.
 > * `hashmap_rs` uses the `fxhash` crate, which is the same as `std::collections::HashMap`, but with a deterministic hasher. This ensures reproducible result.
-> * `rbtree`'s `remove` method only performs logical removal of the elements. The removed elements still reside in memory, but not reachable from the map. A complete implementation of `remove` would cost a bit more than reported here.
 > * `btree` comes from [Byron Becker's stable BTreeMap library](https://github.com/canscale/StableHeapBTreeMap).
 > * `zhenya_hashmap` comes from [Zhenya Usenko's stable HashMap library](https://github.com/ZhenyaUsenko/motoko-hash-map).
 > * The MoVM table measures the performance of an experimental implementation of Motoko interpreter. External developers can ignore this table for now.

--- a/gc/README.md
+++ b/gc/README.md
@@ -1,6 +1,6 @@
 # Motoko Garbage Collection
 
-Measure Motoko garbage collection cost using the [Triemap benchmark](https://github.com/dfinity/canister-profiling/blob/main/collections/motoko/src/triemap.mo). The max mem column reports `rts_max_live_size` after `generate` call.
+Measure Motoko garbage collection cost using the [Triemap benchmark](https://github.com/dfinity/canister-profiling/blob/main/collections/motoko/src/triemap.mo). The max mem column reports `rts_max_live_size` after `generate` call. The cycle cost numbers reported here are garbage collection cost only. Some flamegraphs are truncated due to the 2M log size limit.
 
 * default. Compile with the default GC option. With the current GC scheduler, `generate` will trigger the copying GC. The rest of the methods will not trigger GC.
 * copying. Compile with `--force-gc --copying-gc`.

--- a/gc/perf.sh
+++ b/gc/perf.sh
@@ -1,10 +1,10 @@
 #!ic-repl
 load "../prelude.sh";
 
-let default = wasm_profiling("default.wasm");
-let copying = wasm_profiling("copying.wasm");
-let compacting = wasm_profiling("compacting.wasm");
-let generational = wasm_profiling("generational.wasm");
+let default = wasm_profiling("default.wasm", vec{"schedule_copying_gc"});
+let copying = wasm_profiling("copying.wasm", vec {"copying_gc"});
+let compacting = wasm_profiling("compacting.wasm", vec{"compacting_gc"});
+let generational = wasm_profiling("generational.wasm", vec{"generational_gc"});
 
 let file = "README.md";
 output(file, "\n| |generate 80k|max mem|batch_get 50|batch_put 50|batch_remove 50|\n|--:|--:|--:|--:|--:|--:|\n");
@@ -13,13 +13,13 @@ function perf_mo(wasm, title, init) {
   let cid = install(wasm, encode (), null);
   
   output(file, stringify("|", title, "|"));
-  call cid.__toggle_tracing();
   call cid.generate(init);
-  output(file, stringify(__cost__, "|"));
+  let svg = stringify(title, "_init.svg");
+  output(file, stringify("[", __cost__, "](", svg, ")|"));
+  flamegraph(cid, stringify(title, ".generate"), svg);
   call cid.get_mem();
   output(file, stringify(_[2], "|"));
   
-  call cid.__toggle_tracing();
   call cid.batch_get(50);
   let svg = stringify(title, "_get.svg");
   output(file, stringify("[", __cost__, "](", svg, ")|"));

--- a/pub-sub/motoko/perf.sh
+++ b/pub-sub/motoko/perf.sh
@@ -7,16 +7,16 @@ let pub = install(pub_wasm, encode (), null);
 let sub = install(sub_wasm, encode (), null);
 
 let file = "README.md";
-output(file, "\n| |pub_binary_size|sub_binary_size|subscribe|publish|\n|--|--:|--:|--:|--:|\n");
+output(file, "\n| |pub_binary_size|sub_binary_size|subscribe_caller|subscribe_callee|publish_caller|publish_callee|\n|--|--:|--:|--:|--:|--:|--:|\n");
 
 let caller = call sub.init(stringify(pub), "Apples");
 flamegraph(sub, "Subscribe Apples", "mo_subscribe.svg");
 let callee_cost = flamegraph(pub, "Register subscriber (called by sub canister)", "mo_pub_register.svg");
-output(file, stringify("|Motoko|", pub_wasm.size(), "|", sub_wasm.size(), "|[caller (", __cost_caller, ")](mo_subscribe.svg) / [callee (", callee_cost, ")](mo_pub_register.svg)|"));
+output(file, stringify("|Motoko|", pub_wasm.size(), "|", sub_wasm.size(), "|[", __cost_caller, "](mo_subscribe.svg)|[", callee_cost, "](mo_pub_register.svg)|"));
 
 let caller = call pub.publish(record { topic = "Apples"; value = 42 });
 flamegraph(pub, "Publish Apples", "mo_publish.svg");
 call sub.getCount();
 assert _ == (42 : nat);
 let callee_cost = flamegraph(sub, "Update subscriber (callback from pub canister)", "mo_sub_update.svg");
-output(file, stringify("[caller (", __cost_caller, ")](mo_publish.svg) / [callee (", callee_cost, ")](mo_sub_update.svg)|\n"));
+output(file, stringify("[", __cost_caller, "](mo_publish.svg)|[", callee_cost, "](mo_sub_update.svg)|\n"));

--- a/pub-sub/rust/perf.sh
+++ b/pub-sub/rust/perf.sh
@@ -11,11 +11,11 @@ let file = "README.md";
 let caller = call sub.setup_subscribe(pub, "Apples");
 flamegraph(sub, "Subscribe Apples", "rs_subscribe.svg");
 let callee_cost = flamegraph(pub, "Register subscriber (called by sub canister)", "rs_pub_register.svg");
-output(file, stringify("|Rust|", pub_wasm.size(), "|", sub_wasm.size(), "|[caller (", __cost_caller, ")](rs_subscribe.svg) / [callee (", callee_cost, ")](rs_pub_register.svg)|"));
+output(file, stringify("|Rust|", pub_wasm.size(), "|", sub_wasm.size(), "|[", __cost_caller, "](rs_subscribe.svg)|[", callee_cost, "](rs_pub_register.svg)|"));
 
 let caller = call pub.publish(record { topic = "Apples"; value = 42 });
 flamegraph(pub, "Publish Apples", "rs_publish.svg");
 call sub.get_count();
 assert _ == (42 : nat64);
 let callee_cost = flamegraph(sub, "Update subscriber (callback from pub canister)", "rs_sub_update.svg");
-output(file, stringify("[caller (", __cost_caller, ")](rs_publish.svg) / [callee (", callee_cost, ")](rs_sub_update.svg)|\n"));
+output(file, stringify("[", __cost_caller, "](rs_publish.svg)|[", callee_cost, "](rs_sub_update.svg)|\n"));


### PR DESCRIPTION
Notably, when comparing the result between this PR (moc 0.8.4) and main (moc 0.7.6), 
* Almost all benchmarks have 2-3% less cycle consumption. Thanks to the recent compiler perf improvements.
* Triemap `put` and `remove` comsumes 5-6% less cycles. RBTree `put` consumes 9% less cycles, and `remove` consume 8% more cycles (due to the full deletion support). Thanks to the base library improvements.
* I also see some cost increase with async callbacks. See the `pub/sub` and `timer` benchmarks.