### PR TITLE
Bump `dfx` to version `0.14.0`

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      DFX_VERSION: 0.13.1
+      DFX_VERSION: 0.14.0
       VESSEL_VERSION: v0.6.4
       IC_REPL_VERSION: 0.3.18
       MOC_VERSION: 0.8.8

--- a/README.md
+++ b/README.md
@@ -48,4 +48,3 @@ Benchmark_name/
       src/
         lib.rs
 ```
-

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Benchmark_name/
       src/
         lib.rs
 ```
+


### PR DESCRIPTION
Strangely, there are changes in the GC benchmark just from bumping `dfx`.