### PR TITLE
Enable wasm optimizer from `dfx 0.14.0`

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -59,12 +59,16 @@ jobs:
           cd $(dfx cache show)
           wget https://github.com/dfinity/motoko/releases/download/$MOC_VERSION/motoko-linux64-$MOC_VERSION.tar.gz
           tar zxvf motoko-linux64-$MOC_VERSION.tar.gz
-      - name: Install wasm-opt
+      - name: Clone ic-wasm
+        uses: actions/checkout@v3
+        with:
+          repository: 'dfinity/ic-wasm'
+          ref: 'name-section'
+          path: 'ic-wasm'
+      - name: Install ic-wasm
         run: |
-          wget https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz
-          tar -xf binaryen-version_112-x86_64-linux.tar.gz
-          cp ./binaryen-version_112/bin/wasm-opt /usr/local/bin/.
-          chmod +x /usr/local/bin/wasm-opt
+          cd ic-wasm
+          cargo install --path .
       - name: Start dfx
         run: |
           dfx start --background

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -59,6 +59,12 @@ jobs:
           cd $(dfx cache show)
           wget https://github.com/dfinity/motoko/releases/download/$MOC_VERSION/motoko-linux64-$MOC_VERSION.tar.gz
           tar zxvf motoko-linux64-$MOC_VERSION.tar.gz
+      - name: Install wasm-opt
+        run: |
+          wget https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz
+          tar -xf binaryen-version_112-x86_64-linux.tar.gz
+          cp ./binaryen-version_112/bin/wasm-opt /usr/local/bin/.
+          chmod +x /usr/local/bin/wasm-opt
       - name: Start dfx
         run: |
           dfx start --background

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -59,19 +59,7 @@ jobs:
           cd $(dfx cache show)
           wget https://github.com/dfinity/motoko/releases/download/$MOC_VERSION/motoko-linux64-$MOC_VERSION.tar.gz
           tar zxvf motoko-linux64-$MOC_VERSION.tar.gz
-      - name: Clone ic-wasm
-        uses: actions/checkout@v3
-        with:
-          repository: 'dfinity/ic-wasm'
-          ref: 'name-section'
-          path: 'ic-wasm'
-      - name: Install ic-wasm
-        run: |
-          cd ic-wasm
-          cargo build
-          export PATH="target/debug:$PATH"
-          chmod a+x target/debug/ic-wasm
-          cd ..
+          cargo install --git https://github.com/dfinity/ic-wasm.git --branch name-section
       - name: Start dfx
         run: |
           dfx start --background

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -59,7 +59,7 @@ jobs:
           cd $(dfx cache show)
           wget https://github.com/dfinity/motoko/releases/download/$MOC_VERSION/motoko-linux64-$MOC_VERSION.tar.gz
           tar zxvf motoko-linux64-$MOC_VERSION.tar.gz
-          cargo install --git https://github.com/dfinity/ic-wasm.git --branch name-section
+          cargo install --git https://github.com/dfinity/ic-wasm.git
       - name: Start dfx
         run: |
           dfx start --background

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -68,7 +68,10 @@ jobs:
       - name: Install ic-wasm
         run: |
           cd ic-wasm
-          cargo install --path .
+          cargo build
+          export PATH="target/debug:$PATH"
+          chmod a+x target/debug/ic-wasm
+          cd ..
       - name: Start dfx
         run: |
           dfx start --background

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A Wasm optimizer is applied to each Wasm binary before instrumentation (except t
 
 The following optimizations are applied:
 ```
-ic-wasm -o <wasm> <wasm> shrink --optimize O3 --keep-name-section;
+ic-wasm -o <wasm> <wasm> shrink --optimize O3 --keep-name-section
 ```
 
 Note that the name section is preserved in the optimization process. This is because the name section is used by the profiler to produce the flame graphs.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,27 @@ Benchmark_name/
       src/
         lib.rs
 ```
+
+## Wasm Optimizer
+
+A Wasm optimizer is applied to each Wasm binary before instrumentation (except the GC benchmarks). The optimizer can be found in [ic-wasm](https://github.com/dfinity/ic-wasm), which wraps [wasm-opt](https://github.com/WebAssembly/binaryen).
+
+The following optimizations are applied:
+```
+ic-wasm -o <wasm> <wasm> shrink --optimize O3 --keep-name-section;
+```
+
+Note that the name section is preserved in the optimization process. This is because the name section is used by the profiler to produce the flame graphs.
+
+For users who wish to use the optimizer, the easiest way is to enable it via a field in `dfx.json`:
+
+```
+{
+  "canisters": {
+    "my_canister": {
+      "optimize": "cycles"
+    }
+  }
+}
+```
+This, as in most real world uses, removes the name section to minimize the binary size.

--- a/collections/Makefile
+++ b/collections/Makefile
@@ -9,6 +9,8 @@ motoko:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	rm mops.toml; \
 	cd ..
 
@@ -16,6 +18,8 @@ rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 build: motoko rust

--- a/collections/Makefile
+++ b/collections/Makefile
@@ -9,8 +9,8 @@ motoko:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 
@@ -18,8 +18,8 @@ rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 build: motoko rust

--- a/dapps/Makefile
+++ b/dapps/Makefile
@@ -7,12 +7,16 @@ motoko:
 	cd motoko; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 build: motoko rust

--- a/dapps/Makefile
+++ b/dapps/Makefile
@@ -7,16 +7,16 @@ motoko:
 	cd motoko; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 build: motoko rust

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -9,6 +9,8 @@ motoko:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	rm mops.toml; \
 	cd ..
 
@@ -16,6 +18,8 @@ rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 build: motoko rust

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -9,8 +9,8 @@ motoko:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 
@@ -18,8 +18,8 @@ rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 build: motoko rust

--- a/motoko/Makefile
+++ b/motoko/Makefile
@@ -8,8 +8,8 @@ build:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 

--- a/motoko/Makefile
+++ b/motoko/Makefile
@@ -10,6 +10,7 @@ build:
 	dfx build; \
 	echo "Optimize with ic-wasm level 3"; \
 	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
+	for f in /*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 

--- a/motoko/Makefile
+++ b/motoko/Makefile
@@ -10,7 +10,7 @@ build:
 	dfx build; \
 	echo "Optimize with ic-wasm level 3"; \
 	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
-	for f in /*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
+	for f in *.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 

--- a/motoko/Makefile
+++ b/motoko/Makefile
@@ -8,6 +8,8 @@ build:
 	mops install; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	rm mops.toml; \
 	cd ..
 

--- a/motoko/Makefile
+++ b/motoko/Makefile
@@ -10,7 +10,6 @@ build:
 	dfx build; \
 	echo "Optimize with ic-wasm level 3"; \
 	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
-	for f in *.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	rm mops.toml; \
 	cd ..
 

--- a/motoko/README.md
+++ b/motoko/README.md
@@ -2,7 +2,7 @@
 
 Measure various features only available in Motoko.
 
-* Garbage Collection. Measure Motoko garbage collection cost using the [Triemap benchmark](https://github.com/dfinity/canister-profiling/blob/main/collections/motoko/src/triemap.mo). The max mem column reports `rts_max_live_size` after `generate` call. The cycle cost numbers reported here are garbage collection cost only. Some flamegraphs are truncated due to the 2M log size limit.
+* Garbage Collection. Measure Motoko garbage collection cost using the [Triemap benchmark](https://github.com/dfinity/canister-profiling/blob/main/collections/motoko/src/triemap.mo). The max mem column reports `rts_max_live_size` after `generate` call. The cycle cost numbers reported here are garbage collection cost only. Some flamegraphs are truncated due to the 2M log size limit. The `dfx`/`ic-wasm` optimizer is disabled for the garbage collection test cases due to how the optimizer affects function names, making profiling trickier.  
 
   - default. Compile with the default GC option. With the current GC scheduler, `generate` will trigger the copying GC. The rest of the methods will not trigger GC.
   - copying. Compile with `--force-gc --copying-gc`.

--- a/pub-sub/Makefile
+++ b/pub-sub/Makefile
@@ -7,12 +7,16 @@ motoko:
 	cd motoko; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
+	echo "Optimize with wasm-opt level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
 	cd ..
 
 build: motoko rust

--- a/pub-sub/Makefile
+++ b/pub-sub/Makefile
@@ -7,16 +7,16 @@ motoko:
 	cd motoko; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 rust:
 	cd rust; \
 	dfx canister create --all; \
 	dfx build; \
-	echo "Optimize with wasm-opt level 3"; \
-	for f in .dfx/local/canisters/*/*.wasm; do wasm-opt -O3 -g -o $$f $$f; done; \
+	echo "Optimize with ic-wasm level 3"; \
+	for f in .dfx/local/canisters/*/*.wasm; do ic-wasm -o $$f $$f shrink --optimize O3 --keep-name-section; done; \
 	cd ..
 
 build: motoko rust


### PR DESCRIPTION
I think it would be good to merge this so that we can measure performance improvements beyond `wasm-opt` and not reimplement optimizations already included in the optimizer.

Note that these benchmarks directly use`ic-wasm` instead of using the `optimize: "cycles"` feature in `dfx` in order to preserve the `wasm` name sections for the flame graphs. For any users reading this, for the general case we recommend using the optimizer through `dfx` instead as the binary size reductions will be better when dropping the name sections. 

For future reference: https://github.com/dfinity/sdk/pull/3090
See also #50 for previous discussions. 