### PR TITLE
use mops for all motoko benchmarks

### DIFF
--- a/crypto/motoko/mops.template.toml
+++ b/crypto/motoko/mops.template.toml
@@ -1,4 +1,4 @@
 [dependencies]
 base = "https://github.com/dfinity/motoko-base#moc-$MOC_VERSION"
-sha2 = "0.0.2"
+sha2 = "0.0.4"
 ic-certification = "https://github.com/nomeata/ic-certification#main"

--- a/dapps/Makefile
+++ b/dapps/Makefile
@@ -4,7 +4,7 @@ include ../*.mk
 all: build perf
 
 motoko:
-	$(call build,motoko)
+	$(call build_with_mops,motoko)
 
 rust:
 	$(call build,rust)

--- a/dapps/motoko/dfx.json
+++ b/dapps/motoko/dfx.json
@@ -6,5 +6,11 @@
     "basic_dao": {
       "main": "basic_dao/Main.mo"
     }
+  },
+  "defaults": {
+    "build": {
+      "packtool": "mops sources",
+      "args": ""
+    }
   }
 }

--- a/dapps/motoko/mops.template.toml
+++ b/dapps/motoko/mops.template.toml
@@ -1,0 +1,2 @@
+[dependencies]
+base = "https://github.com/dfinity/motoko-base#moc-$MOC_VERSION"

--- a/pub-sub/Makefile
+++ b/pub-sub/Makefile
@@ -4,7 +4,7 @@ include ../*.mk
 all: build perf
 
 motoko:
-	$(call build,motoko)
+	$(call build_with_mops,motoko)
 
 rust:
 	$(call build,rust)

--- a/pub-sub/motoko/dfx.json
+++ b/pub-sub/motoko/dfx.json
@@ -6,5 +6,11 @@
     "sub": {
       "main": "src/sub/Main.mo"
     }
+  },
+  "defaults": {
+    "build": {
+      "packtool": "mops sources",
+      "args": ""
+    }
   }
 }

--- a/pub-sub/motoko/mops.template.toml
+++ b/pub-sub/motoko/mops.template.toml
@@ -1,0 +1,2 @@
+[dependencies]
+base = "https://github.com/dfinity/motoko-base#moc-$MOC_VERSION"


### PR DESCRIPTION
* This also allows to tune the build script for Motoko and Rust separately. Helps the skewness of #83 
* Bump sha2 to 0.0.4